### PR TITLE
feat: redis init

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
 	"dependencies": {
 		"@cloudflare/workers-oauth-provider": "^0.0.6",
 		"@modelcontextprotocol/sdk": "1.17.1",
+		"@upstash/redis": "^1.35.3",
 		"agents": "^0.0.109",
 		"axios": "^1.11.0",
 		"crypto-js": "^4.2.0",
 		"hono": "^4.9.0",
+		"ioredis": "^5.7.0",
 		"oauth-1.0a": "^2.2.6",
 		"zod": "^3.25.67"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.17.1
         version: 1.17.1
+      '@upstash/redis':
+        specifier: ^1.35.3
+        version: 1.35.3
       agents:
         specifier: ^0.0.109
         version: 0.0.109(@cloudflare/workers-types@4.20250807.0)(react@19.1.1)
@@ -26,6 +29,9 @@ importers:
       hono:
         specifier: ^4.9.0
         version: 4.9.0
+      ioredis:
+        specifier: ^5.7.0
+        version: 5.7.0
       oauth-1.0a:
         specifier: ^2.2.6
         version: 2.2.6
@@ -449,6 +455,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.3.0':
+    resolution: {integrity: sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -491,6 +500,9 @@ packages:
 
   '@types/node@24.2.0':
     resolution: {integrity: sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==}
+
+  '@upstash/redis@1.35.3':
+    resolution: {integrity: sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -551,6 +563,10 @@ packages:
   chalk@5.5.0:
     resolution: {integrity: sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -623,6 +639,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -790,6 +810,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ioredis@5.7.0:
+    resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -820,6 +844,12 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -957,6 +987,14 @@ packages:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -1017,6 +1055,9 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -1060,6 +1101,9 @@ packages:
 
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
@@ -1398,6 +1442,8 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@ioredis/commands@1.3.0': {}
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
@@ -1449,6 +1495,10 @@ snapshots:
   '@types/node@24.2.0':
     dependencies:
       undici-types: 7.10.0
+
+  '@upstash/redis@1.35.3':
+    dependencies:
+      uncrypto: 0.1.3
 
   accepts@2.0.0:
     dependencies:
@@ -1533,6 +1583,8 @@ snapshots:
 
   chalk@5.5.0: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -1589,6 +1641,8 @@ snapshots:
   defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -1787,6 +1841,20 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ioredis@5.7.0:
+    dependencies:
+      '@ioredis/commands': 1.3.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.1
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.3.2: {}
@@ -1808,6 +1876,10 @@ snapshots:
       diff-match-patch: 1.0.5
 
   kleur@4.1.5: {}
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -1923,6 +1995,12 @@ snapshots:
 
   react@19.1.1: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   router@2.2.0:
     dependencies:
       debug: 4.4.1
@@ -2032,6 +2110,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
+  standard-as-callback@2.1.0: {}
+
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
@@ -2062,6 +2142,8 @@ snapshots:
   typescript@5.8.3: {}
 
   ufo@1.6.1: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@7.10.0: {}
 

--- a/src/lib/authHandler/index.ts
+++ b/src/lib/authHandler/index.ts
@@ -1,7 +1,7 @@
 import { Context, Hono } from "hono";
 import { SplitwiseAuthService } from "../splitwise";
 import { Env } from "../../types";
-import { requestTokensState, users } from "../users";
+import { RedisGlobalStore } from "../users";
 
 type Variables = {
 	userId: string;
@@ -22,6 +22,11 @@ app.get("/authorize/:id", async (cxt: Context) => {
 			cxt.env.SPLITWISE_CALLBACK_URL!
 		);
 
+		const redis = new RedisGlobalStore({
+			url: cxt.env.REDIS_URL!,
+			token: cxt.env.REDIS_TOKEN!,
+		});
+
 		const tokens = await splitwiseAuth.getRequestToken();
 
 		if (!tokens.requestToken || !tokens.requestTokenSecret) {
@@ -29,13 +34,13 @@ app.get("/authorize/:id", async (cxt: Context) => {
 		}
 
 		// Store request token and secret in the users map
-		users.set(userId, {
+		await redis.setUser(userId, {
 			id: userId,
 			requestToken: tokens.requestToken,
 			requestTokenSecret: tokens.requestTokenSecret,
 		});
 
-		requestTokensState.set(tokens.requestToken, {
+		await redis.setRequestToken(tokens.requestToken, {
 			id: userId,
 		});
 
@@ -57,18 +62,25 @@ app.get("/callback", async (cxt: Context) => {
 		const oauth_token = cxt.req.query("oauth_token");
 		const oauth_verifier = cxt.req.query("oauth_verifier");
 
+		const redis = new RedisGlobalStore({
+			url: cxt.env.REDIS_URL!,
+			token: cxt.env.REDIS_TOKEN!,
+		});
+
 		if (!oauth_token || !oauth_verifier) {
 			return cxt.json({ error: "Missing required parameters" }, 400);
 		}
 
-		const userId = requestTokensState.get(oauth_token)?.id;
+		const user = await redis.getRequestToken(oauth_token);
+
+		const userId = user?.id;
 
 		if (!userId) {
 			return cxt.json({ error: "Invalid or expired session" }, 400);
 		}
 
 		// Retrieve stored tokens
-		const storedTokens = users.get(userId);
+		const storedTokens = await redis.getUser(userId);
 		if (
 			!storedTokens ||
 			!storedTokens.requestToken ||
@@ -96,7 +108,7 @@ app.get("/callback", async (cxt: Context) => {
 		}
 
 		// Store access tokens in the user map
-		users.set(userId, {
+		await redis.setUser(userId, {
 			id: userId,
 			access_token: accessTokens.accessToken,
 			accessTokenSecret: accessTokens.accessTokenSecret,
@@ -105,7 +117,6 @@ app.get("/callback", async (cxt: Context) => {
 		});
 
 		// Clean up request token state
-		requestTokensState.delete(oauth_token);
 
 		return cxt.json({
 			success: true,
@@ -121,7 +132,12 @@ app.get("/callback", async (cxt: Context) => {
 app.get("/token/:id", async (ctx: Context) => {
 	const userId = ctx.req.param("id");
 
-	const user = users.get(userId);
+	const redis = new RedisGlobalStore({
+		url: ctx.env.REDIS_URL!,
+		token: ctx.env.REDIS_TOKEN!,
+	});
+
+	const user = await redis.getUser(userId);
 
 	if (!user) {
 		return ctx.json({

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,5 +1,294 @@
-import { IUsers } from "../types";
+import { Redis } from "@upstash/redis";
+import { IRequestTokenState, IUsers } from "../types";
 
-export let users: Map<string, IUsers> = new Map();
+export class RedisGlobalStore {
+	private redis: Redis;
+	private readonly USERS_PREFIX = "users:";
+	private readonly REQUEST_TOKENS_PREFIX = "request_tokens:";
 
-export let requestTokensState: Map<string, { id: string;}> = new Map();
+	constructor({ url, token }: { url: string; token: string }) {
+		this.redis = new Redis({
+			url: url,
+			token: token,
+		});
+	}
+
+	// Users Map equivalent methods
+	async setUser(key: string, user: IUsers): Promise<void> {
+		try {
+			const redisKey = `${this.USERS_PREFIX}${key}`;
+			await this.redis.hset(
+				redisKey,
+				user as unknown as Record<string, unknown>
+			);
+
+			// Optional: Set expiration (e.g., 24 hours)
+			// await this.redis.expire(redisKey, 24 * 60 * 60);
+		} catch (error) {
+			console.error("Error setting user:", error);
+			throw error;
+		}
+	}
+
+	async getUser(key: string): Promise<IUsers | undefined> {
+		try {
+			const redisKey = `${this.USERS_PREFIX}${key}`;
+			const userData = await this.redis.hgetall(redisKey);
+
+			if (!userData || Object.keys(userData).length === 0) {
+				return undefined;
+			}
+
+			return {
+				id: (userData.id as string) || "",
+				access_token: userData.access_token as string | undefined,
+				accessTokenSecret: userData.accessTokenSecret as string | undefined,
+				requestToken: userData.requestToken as string | undefined,
+				requestTokenSecret: userData.requestTokenSecret as string | undefined,
+			} as IUsers;
+		} catch (error) {
+			console.error("Error getting user:", error);
+			throw error;
+		}
+	}
+
+	async hasUser(key: string): Promise<boolean> {
+		try {
+			const redisKey = `${this.USERS_PREFIX}${key}`;
+			const exists = await this.redis.exists(redisKey);
+			return exists === 1;
+		} catch (error) {
+			console.error("Error checking user existence:", error);
+			throw error;
+		}
+	}
+
+	async deleteUser(key: string): Promise<boolean> {
+		try {
+			const redisKey = `${this.USERS_PREFIX}${key}`;
+			const result = await this.redis.del(redisKey);
+			return result > 0;
+		} catch (error) {
+			console.error("Error deleting user:", error);
+			throw error;
+		}
+	}
+
+	async getAllUsers(): Promise<Map<string, IUsers>> {
+		try {
+			const pattern = `${this.USERS_PREFIX}*`;
+			const keys = await this.redis.keys(pattern);
+			const usersMap = new Map<string, IUsers>();
+
+			for (const redisKey of keys) {
+				const userData = await this.redis.hgetall(redisKey);
+				if (userData && Object.keys(userData).length > 0) {
+					const originalKey = redisKey.replace(this.USERS_PREFIX, "");
+					usersMap.set(originalKey, {
+						id: (userData.id as string) || "",
+						access_token: userData.access_token as string | undefined,
+						accessTokenSecret: userData.accessTokenSecret as string | undefined,
+						requestToken: userData.requestToken as string | undefined,
+						requestTokenSecret: userData.requestTokenSecret as
+							| string
+							| undefined,
+					});
+				}
+			}
+
+			return usersMap;
+		} catch (error) {
+			console.error("Error getting all users:", error);
+			throw error;
+		}
+	}
+
+	async getUsersSize(): Promise<number> {
+		try {
+			const pattern = `${this.USERS_PREFIX}*`;
+			const keys = await this.redis.keys(pattern);
+			return keys.length;
+		} catch (error) {
+			console.error("Error getting users size:", error);
+			throw error;
+		}
+	}
+
+	async clearUsers(): Promise<void> {
+		try {
+			const pattern = `${this.USERS_PREFIX}*`;
+			const keys = await this.redis.keys(pattern);
+			if (keys.length > 0) {
+				await this.redis.del(...keys);
+			}
+		} catch (error) {
+			console.error("Error clearing users:", error);
+			throw error;
+		}
+	}
+
+	// Request Tokens State Map equivalent methods
+	async setRequestToken(
+		key: string,
+		tokenState: IRequestTokenState
+	): Promise<void> {
+		try {
+			const redisKey = `${this.REQUEST_TOKENS_PREFIX}${key}`;
+			await this.redis.hset(
+				redisKey,
+				tokenState as unknown as Record<string, unknown>
+			);
+
+			// Set expiration for request tokens (e.g., 15 minutes)
+			await this.redis.expire(redisKey, 15 * 60);
+		} catch (error) {
+			console.error("Error setting request token:", error);
+			throw error;
+		}
+	}
+
+	async getRequestToken(key: string): Promise<IRequestTokenState | undefined> {
+		try {
+			const redisKey = `${this.REQUEST_TOKENS_PREFIX}${key}`;
+			const tokenData = await this.redis.hgetall(redisKey);
+
+			if (!tokenData || Object.keys(tokenData).length === 0) {
+				return undefined;
+			}
+
+			return {
+				id: tokenData.id as string,
+			};
+		} catch (error) {
+			console.error("Error getting request token:", error);
+			throw error;
+		}
+	}
+
+	async hasRequestToken(key: string): Promise<boolean> {
+		try {
+			const redisKey = `${this.REQUEST_TOKENS_PREFIX}${key}`;
+			const exists = await this.redis.exists(redisKey);
+			return exists === 1;
+		} catch (error) {
+			console.error("Error checking request token existence:", error);
+			throw error;
+		}
+	}
+
+	async deleteRequestToken(key: string): Promise<boolean> {
+		try {
+			const redisKey = `${this.REQUEST_TOKENS_PREFIX}${key}`;
+			const result = await this.redis.del(redisKey);
+			return result > 0;
+		} catch (error) {
+			console.error("Error deleting request token:", error);
+			throw error;
+		}
+	}
+
+	async getAllRequestTokens(): Promise<Map<string, IRequestTokenState>> {
+		try {
+			const pattern = `${this.REQUEST_TOKENS_PREFIX}*`;
+			const keys = await this.redis.keys(pattern);
+			const tokensMap = new Map<string, IRequestTokenState>();
+
+			for (const redisKey of keys) {
+				const tokenData = await this.redis.hgetall(redisKey);
+				if (tokenData && Object.keys(tokenData).length > 0) {
+					const originalKey = redisKey.replace(this.REQUEST_TOKENS_PREFIX, "");
+					tokensMap.set(originalKey, { id: tokenData.id as string });
+				}
+			}
+
+			return tokensMap;
+		} catch (error) {
+			console.error("Error getting all request tokens:", error);
+			throw error;
+		}
+	}
+
+	async getRequestTokensSize(): Promise<number> {
+		try {
+			const pattern = `${this.REQUEST_TOKENS_PREFIX}*`;
+			const keys = await this.redis.keys(pattern);
+			return keys.length;
+		} catch (error) {
+			console.error("Error getting request tokens size:", error);
+			throw error;
+		}
+	}
+
+	async clearRequestTokens(): Promise<void> {
+		try {
+			const pattern = `${this.REQUEST_TOKENS_PREFIX}*`;
+			const keys = await this.redis.keys(pattern);
+			if (keys.length > 0) {
+				await this.redis.del(...keys);
+			}
+		} catch (error) {
+			console.error("Error clearing request tokens:", error);
+			throw error;
+		}
+	}
+
+	// Update specific user fields (useful for OAuth flow)
+	async updateUser(key: string, updates: Partial<IUsers>): Promise<void> {
+		try {
+			const redisKey = `${this.USERS_PREFIX}${key}`;
+			await this.redis.hset(
+				redisKey,
+				updates as unknown as Record<string, unknown>
+			);
+		} catch (error) {
+			console.error("Error updating user:", error);
+			throw error;
+		}
+	}
+
+	// Batch operations for better performance
+	async setMultipleUsers(users: Map<string, IUsers>): Promise<void> {
+		try {
+			const pipeline = this.redis.pipeline();
+
+			users.forEach((user, key) => {
+				const redisKey = `${this.USERS_PREFIX}${key}`;
+				pipeline.hset(redisKey, user as unknown as Record<string, unknown>);
+			});
+
+			await pipeline.exec();
+		} catch (error) {
+			console.error("Error setting multiple users:", error);
+			throw error;
+		}
+	}
+
+	async setMultipleRequestTokens(
+		tokens: Map<string, IRequestTokenState>
+	): Promise<void> {
+		try {
+			const pipeline = this.redis.pipeline();
+
+			tokens.forEach((token, key) => {
+				const redisKey = `${this.REQUEST_TOKENS_PREFIX}${key}`;
+				pipeline.hset(redisKey, token as unknown as Record<string, unknown>);
+				pipeline.expire(redisKey, 15 * 60); // 15 minutes expiration
+			});
+
+			await pipeline.exec();
+		} catch (error) {
+			console.error("Error setting multiple request tokens:", error);
+			throw error;
+		}
+	}
+
+	// Close connection - Note: Upstash Redis doesn't require explicit connection closing
+	async close(): Promise<void> {
+		// No-op for Upstash Redis as it's serverless
+	}
+
+	// Get Redis instance for advanced operations
+	getRedisInstance(): Redis {
+		return this.redis;
+	}
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,8 +3,9 @@ export interface Env {
 	SPLITWISE_CONSUMER_SECRET?: string;
 	SPLITWISE_CALLBACK_URL?: string;
 	BACKEND_URL?: string;
+	REDIS_URL?: string;
+	REDIS_TOKEN?: string;
 }
-
 export interface IUsers {
 	id: string;
 	access_token?: string;
@@ -18,4 +19,8 @@ export interface AddUserToGroupRequest {
 	userEmail: string;
 	firstName?: string;
 	lastName?: string;
+}
+
+export interface IRequestTokenState {
+	id: string;
 }


### PR DESCRIPTION
This pull request introduces Redis-backed storage for user and request token data, replacing the previous in-memory solution. It adds the necessary dependencies and updates the main MCP agent class to use the new Redis-based storage interface for all user and token operations.

Dependency updates:

* Added `@upstash/redis` and `ioredis` as dependencies in `package.json` and updated `pnpm-lock.yaml` to include these and their transitive dependencies, enabling Redis support in the project. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17-R22) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17-R19) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR32-R34) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR458-R460) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR504-R506) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR567-R570) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR643-R646) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR813-R816) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR848-R853) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR990-R997) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1058-R1060) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1105-R1107) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1445-R1446) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1499-R1502) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1586-R1587) [[16]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1645-R1646) [[17]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1844-R1857) [[18]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1880-R1883) [[19]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1998-R2003) [[20]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2113-R2114) [[21]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2146-R2147)

Refactor to Redis-backed storage:

* Updated the MCP agent class (`MyMCP` in `src/index.ts`) to use a new `RedisGlobalStore` for user and request token state, replacing the previous in-memory `users` object. All tool methods now use asynchronous Redis-backed methods to get/set user data and tokens. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L6-R7) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L22-R109)
* Replaced all synchronous `users.get(...)` calls with asynchronous `await this.users.get(...)` calls throughout the MCP agent's tool implementations, ensuring compatibility with the new Redis-based storage. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L109-R171) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L165-R227) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L223-R285) [[4]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L288-R350) [[5]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L348-R410) [[6]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L408-R470) [[7]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L471-R533) [[8]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L541-R603) [[9]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L600-R662) [[10]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L658-R720)